### PR TITLE
Add streaming pipeline scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A full-stack, containerized web application that automatically detects, classifi
 - [Features](#features)
 - [System Architecture](#system-architecture)
 - [Technology Stack](#technology-stack)
+- [Data Engineering Pipeline](#data-engineering-pipeline)
 - [Setup & Installation](#setup--installation)
 - [Project Structure](#project-structure)
 - [Handling Critical Challenges](#handling-critical-challenges)
@@ -84,6 +85,24 @@ A full-stack, containerized web application that automatically detects, classifi
 - **Worker:** Celery process for long-running video processing tasks.
 - **AWS S3:** Centralized video and frame storage.
 - **Docker Compose:** Orchestrates all services for seamless dev/prod setup.
+
+---
+
+## Data Engineering Pipeline
+
+```
++---------------+        +-------+        +---------------------------+        +----------------+
+| Celery Worker | -----> | Kafka | -----> | Spark Structured Streaming | -----> | Delta Lake on S3 |
++---------------+        +-------+        +---------------------------+        +----------------+
+                                                                              |
+                                                                              v
+                                                                        Airflow / dbt
+```
+
+- Celery workers publish detection events to **Kafka**.
+- **Spark Structured Streaming** validates events and writes curated tables to **Delta Lake on S3**.
+- **dbt** models query Silver tables for analytics, while **Airflow** orchestrates streaming and batch jobs.
+- Optional **Great Expectations** checks ensure data quality before promotion.
 
 ---
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -27,3 +27,4 @@ eventlet==0.40.0
 reportlab==4.0.4
 
 setuptools>=65.0.0
+confluent-kafka==2.3.0

--- a/backend/services/kafka_producer.py
+++ b/backend/services/kafka_producer.py
@@ -1,0 +1,11 @@
+from confluent_kafka import Producer
+import json
+import os
+
+producer = Producer({"bootstrap.servers": os.getenv("KAFKA_BOOTSTRAP", "kafka:9092")})
+
+
+def publish_detection(event: dict, topic: str = "wagon.detections.v1") -> None:
+    """Publish a detection event to the configured Kafka topic."""
+    producer.produce(topic, json.dumps(event).encode("utf-8"))
+    producer.flush()

--- a/dbt_wagon/models/detections_clean.sql
+++ b/dbt_wagon/models/detections_clean.sql
@@ -1,0 +1,11 @@
+select job_id,
+       wagon_id,
+       ts,
+       model_version,
+       inference_ms,
+       label,
+       confidence,
+       bbox,
+       severity
+from delta.`s3a://<bucket>/delta/silver/detections`
+where confidence >= 0.5

--- a/docker/docker-compose.de.yml
+++ b/docker/docker-compose.de.yml
@@ -1,0 +1,41 @@
+services:
+  zookeeper:
+    image: bitnami/zookeeper:3.9
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: "yes"
+  kafka:
+    image: bitnami/kafka:3.7
+    environment:
+      KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: PLAINTEXT://:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+    depends_on:
+      - zookeeper
+
+  spark-master:
+    image: bitnami/spark:3.5
+    environment:
+      SPARK_MODE: master
+    volumes:
+      - ../spark_jobs:/opt/spark-apps
+  spark-worker:
+    image: bitnami/spark:3.5
+    environment:
+      SPARK_MODE: worker
+      SPARK_MASTER_URL: spark://spark-master:7077
+    depends_on:
+      - spark-master
+    volumes:
+      - ../spark_jobs:/opt/spark-apps
+
+  airflow:
+    image: apache/airflow:2.9.3
+    environment:
+      - AIRFLOW__CORE__LOAD_EXAMPLES=false
+    volumes:
+      - ../airflow/dags:/opt/airflow/dags
+      - ../spark_jobs:/opt/spark-apps
+    command: webserver
+    depends_on:
+      - spark-master
+      - kafka

--- a/spark_jobs/stream_detections_to_delta.py
+++ b/spark_jobs/stream_detections_to_delta.py
@@ -1,0 +1,74 @@
+from pyspark.sql import SparkSession, functions as F, types as T
+
+spark = (
+    SparkSession.builder.appName("wagon-detections-stream")
+    .config("spark.sql.streaming.schemaInference", "true")
+    .getOrCreate()
+)
+
+raw = (
+    spark.readStream.format("kafka")
+    .option("kafka.bootstrap.servers", "kafka:9092")
+    .option("subscribe", "wagon.detections.v1")
+    .option("startingOffsets", "latest")
+    .load()
+)
+
+events = (
+    raw.selectExpr("CAST(value AS STRING) as json")
+    .select(F.from_json("json", T.StringType()).alias("raw_json"))
+    .select(
+        F.from_json(
+            "raw_json",
+            T.SchemaOfJson(
+                """
+            {"event_version":1,"job_id":"", "frame_s3_uri":"", "wagon_id":"",
+            "timestamp":"", "model_version":"", "detections":[], "inference_ms":0}
+            """
+            ),
+        ).alias("e")
+    )
+    .select("e.*")
+    .withColumn("ts", F.to_timestamp("timestamp"))
+    .withWatermark("ts", "10 minutes")
+)
+
+# Bronze table
+(
+    events.writeStream.format("delta")
+    .option(
+        "checkpointLocation",
+        "s3a://<bucket>/delta/bronze/_checkpoints/detections",
+    )
+    .outputMode("append")
+    .start("s3a://<bucket>/delta/bronze/detections")
+)
+
+# Silver table
+flat = (
+    events.withColumn("det", F.explode("detections"))
+    .select(
+        "job_id",
+        "wagon_id",
+        "ts",
+        "model_version",
+        "inference_ms",
+        F.col("det.label").alias("label"),
+        F.col("det.confidence").alias("confidence"),
+        F.col("det.bbox").alias("bbox"),
+        F.col("det.severity").alias("severity"),
+    )
+)
+
+(
+    flat.writeStream.format("delta")
+    .option(
+        "checkpointLocation",
+        "s3a://<bucket>/delta/silver/_checkpoints/detections",
+    )
+    .partitionBy("wagon_id")
+    .outputMode("append")
+    .start("s3a://<bucket>/delta/silver/detections")
+)
+
+spark.streams.awaitAnyTermination()


### PR DESCRIPTION
## Summary
- publish frame detection events to Kafka from Celery worker
- scaffold Spark Structured Streaming job and Delta landing
- document data engineering pipeline and add dbt & docker assets

## Testing
- `python -m py_compile backend/services/kafka_producer.py backend/services/celery_worker.py spark_jobs/stream_detections_to_delta.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8e2674f0083249e5675de763d8f99